### PR TITLE
Update

### DIFF
--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
@@ -23,6 +23,9 @@
 @property (nonatomic, assign) id<VPImageCropperDelegate> delegate;
 @property (nonatomic, assign) CGRect cropFrame;
 @property (nonatomic, assign) UIColor *borderColor;
+@property (nonatomic, strong) UIButton *cancelBtn;
+@property (nonatomic, strong) UIButton *confirmBtn;
+
 - (id)initWithImage:(UIImage *)originalImage cropFrame:(CGRect)cropFrame limitScaleRatio:(NSInteger)limitRatio;
 
 @end

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.h
@@ -22,7 +22,7 @@
 @property (nonatomic, assign) NSInteger tag;
 @property (nonatomic, assign) id<VPImageCropperDelegate> delegate;
 @property (nonatomic, assign) CGRect cropFrame;
-
+@property (nonatomic, assign) UIColor *borderColor;
 - (id)initWithImage:(UIImage *)originalImage cropFrame:(CGRect)cropFrame limitScaleRatio:(NSInteger)limitRatio;
 
 @end

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -55,7 +55,17 @@
 {
     [super viewDidLoad];
     [self initView];
-    [self initControlBtn];
+    
+    if (self.confirmBtn) {
+        [self.confirmBtn addTarget:self action:@selector(confirm:) forControlEvents:UIControlEventTouchUpInside];
+        [self.view addSubview:self.confirmBtn];
+        
+        [self.cancelBtn addTarget:self action:@selector(cancel:) forControlEvents:UIControlEventTouchUpInside];
+        [self.view addSubview:self.cancelBtn];
+    }
+    else {
+        [self initControlBtn];
+    }
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -73,6 +73,8 @@
 }
 
 - (void)initView {
+    self.view.backgroundColor = [UIColor blackColor];
+    
     self.showImgView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)];
     [self.showImgView setMultipleTouchEnabled:YES];
     [self.showImgView setUserInteractionEnabled:YES];
@@ -270,7 +272,7 @@
     CGFloat x = (squareFrame.origin.x - self.latestFrame.origin.x) / scaleRatio;
     CGFloat y = (squareFrame.origin.y - self.latestFrame.origin.y) / scaleRatio;
     CGFloat w = squareFrame.size.width / scaleRatio;
-    CGFloat h = squareFrame.size.width / scaleRatio;
+    CGFloat h = squareFrame.size.height / scaleRatio;
     if (self.latestFrame.size.width < self.cropFrame.size.width) {
         CGFloat newW = self.originalImage.size.width;
         CGFloat newH = newW * (self.cropFrame.size.height / self.cropFrame.size.width);

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -44,6 +44,9 @@
         self.cropFrame = cropFrame;
         self.limitRatio = limitRatio;
         self.originalImage = [self fixOrientation:originalImage];
+        
+        if (!self.borderColor)
+            self.borderColor = [UIColor yellowColor];
     }
     return self;
 }
@@ -89,7 +92,7 @@
     [self.view addSubview:self.overlayView];
     
     self.ratioView = [[UIView alloc] initWithFrame:self.cropFrame];
-    self.ratioView.layer.borderColor = [UIColor yellowColor].CGColor;
+    self.ratioView.layer.borderColor = self.borderColor.CGColor;
     self.ratioView.layer.borderWidth = 1.0f;
     self.ratioView.autoresizingMask = UIViewAutoresizingNone;
     [self.view addSubview:self.ratioView];

--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -101,30 +101,30 @@
 }
 
 - (void)initControlBtn {
-    UIButton *cancelBtn = [[UIButton alloc] initWithFrame:CGRectMake(0, self.view.frame.size.height - 50.0f, 100, 50)];
-    cancelBtn.backgroundColor = [UIColor blackColor];
-    cancelBtn.titleLabel.textColor = [UIColor whiteColor];
-    [cancelBtn setTitle:@"Cancel" forState:UIControlStateNormal];
-    [cancelBtn.titleLabel setFont:[UIFont boldSystemFontOfSize:18.0f]];
-    [cancelBtn.titleLabel setTextAlignment:NSTextAlignmentCenter];
-    [cancelBtn.titleLabel setLineBreakMode:NSLineBreakByWordWrapping];
-    [cancelBtn.titleLabel setNumberOfLines:0];
-    [cancelBtn setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 5.0f, 5.0f, 5.0f)];
-    [cancelBtn addTarget:self action:@selector(cancel:) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:cancelBtn];
+    self.cancelBtn = [[UIButton alloc] initWithFrame:CGRectMake(0, self.view.frame.size.height - 50.0f, 100, 50)];
+    self.cancelBtn.backgroundColor = [UIColor blackColor];
+    self.cancelBtn.titleLabel.textColor = [UIColor whiteColor];
+    [self.cancelBtn setTitle:@"Cancel" forState:UIControlStateNormal];
+    [self.cancelBtn.titleLabel setFont:[UIFont boldSystemFontOfSize:18.0f]];
+    [self.cancelBtn.titleLabel setTextAlignment:NSTextAlignmentCenter];
+    [self.cancelBtn.titleLabel setLineBreakMode:NSLineBreakByWordWrapping];
+    [self.cancelBtn.titleLabel setNumberOfLines:0];
+    [self.cancelBtn setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 5.0f, 5.0f, 5.0f)];
+    [self.cancelBtn addTarget:self action:@selector(cancel:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.cancelBtn];
     
-    UIButton *confirmBtn = [[UIButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width - 100.0f, self.view.frame.size.height - 50.0f, 100, 50)];
-    confirmBtn.backgroundColor = [UIColor blackColor];
-    confirmBtn.titleLabel.textColor = [UIColor whiteColor];
-    [confirmBtn setTitle:@"OK" forState:UIControlStateNormal];
-    [confirmBtn.titleLabel setFont:[UIFont boldSystemFontOfSize:18.0f]];
-    [confirmBtn.titleLabel setTextAlignment:NSTextAlignmentCenter];
-    confirmBtn.titleLabel.textColor = [UIColor whiteColor];
-    [confirmBtn.titleLabel setLineBreakMode:NSLineBreakByWordWrapping];
-    [confirmBtn.titleLabel setNumberOfLines:0];
-    [confirmBtn setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 5.0f, 5.0f, 5.0f)];
-    [confirmBtn addTarget:self action:@selector(confirm:) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:confirmBtn];
+    self.confirmBtn = [[UIButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width - 100.0f, self.view.frame.size.height - 50.0f, 100, 50)];
+    self.confirmBtn.backgroundColor = [UIColor blackColor];
+    self.confirmBtn.titleLabel.textColor = [UIColor whiteColor];
+    [self.confirmBtn setTitle:@"OK" forState:UIControlStateNormal];
+    [self.confirmBtn.titleLabel setFont:[UIFont boldSystemFontOfSize:18.0f]];
+    [self.confirmBtn.titleLabel setTextAlignment:NSTextAlignmentCenter];
+    self.confirmBtn.titleLabel.textColor = [UIColor whiteColor];
+    [self.confirmBtn.titleLabel setLineBreakMode:NSLineBreakByWordWrapping];
+    [self.confirmBtn.titleLabel setNumberOfLines:0];
+    [self.confirmBtn setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 5.0f, 5.0f, 5.0f)];
+    [self.confirmBtn addTarget:self action:@selector(confirm:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.confirmBtn];
 }
 
 - (void)cancel:(id)sender {


### PR DESCRIPTION
Allows for changing border color, button controls

``` objc
        imgCropperVC.borderColor = [UIColor redColor];

        UIButton *confirmBtn = [[UIButton alloc] initWithFrame:CGRectMake(10, 40, 100, 40)];
        confirmBtn.layer.cornerRadius = 2;
        confirmBtn.layer.borderColor = [UIColor redColor].CGColor;
        confirmBtn.layer.borderWidth = 1;
        confirmBtn.backgroundColor = [UIColor whiteColor];
        [confirmBtn setTitleColor:[UIColor redColor] forState:UIControlStateNormal];
        [confirmBtn setTitle:@"Crop" forState:UIControlStateNormal];
        imgCropperVC.confirmBtn = confirmBtn;

        UIButton *cancelBtn = [[UIButton alloc] initWithFrame:CGRectMake(10, 90, 100, 40)];
        cancelBtn.layer.cornerRadius = 2;
        cancelBtn.layer.borderColor = [UIColor grayColor].CGColor;
        cancelBtn.layer.borderWidth = 1;
        cancelBtn.backgroundColor = [UIColor whiteColor];
        [cancelBtn setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
        [cancelBtn setTitle:@"Nevermind" forState:UIControlStateNormal];
        imgCropperVC.cancelBtn = cancelBtn;
```
