### PR TITLE
iOS 13 adaptation

### DIFF
--- a/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
+++ b/VPImageCropperDemo/VPImageCropper/VPImageCropperViewController.m
@@ -100,7 +100,7 @@
 }
 
 - (void)initControlBtn {
-    UIButton *cancelBtn = [[UIButton alloc] initWithFrame:CGRectMake(0, self.view.frame.size.height - 50.0f, 100, 50)];
+    UIButton *cancelBtn = [[UIButton alloc] init];
     cancelBtn.backgroundColor = [UIColor blackColor];
     cancelBtn.titleLabel.textColor = [UIColor whiteColor];
     [cancelBtn setTitle:@"Cancel" forState:UIControlStateNormal];
@@ -111,8 +111,17 @@
     [cancelBtn setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 5.0f, 5.0f, 5.0f)];
     [cancelBtn addTarget:self action:@selector(cancel:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:cancelBtn];
+    cancelBtn.translatesAutoresizingMaskIntoConstraints = false;
+    [[cancelBtn.leftAnchor constraintEqualToAnchor:self.view.leftAnchor constant:0] setActive:true];
+    if (@available(iOS 11.0, *)) {
+        [[cancelBtn.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:0] setActive:true];
+    } else {
+        [[cancelBtn.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor constant:0] setActive:true];
+    }
+    [[cancelBtn.widthAnchor constraintEqualToConstant:100] setActive:true];
+    [[cancelBtn.heightAnchor constraintEqualToConstant:50] setActive:true];
     
-    UIButton *confirmBtn = [[UIButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width - 100.0f, self.view.frame.size.height - 50.0f, 100, 50)];
+    UIButton *confirmBtn = [[UIButton alloc] init];
     confirmBtn.backgroundColor = [UIColor blackColor];
     confirmBtn.titleLabel.textColor = [UIColor whiteColor];
     [confirmBtn setTitle:@"OK" forState:UIControlStateNormal];
@@ -124,6 +133,15 @@
     [confirmBtn setTitleEdgeInsets:UIEdgeInsetsMake(5.0f, 5.0f, 5.0f, 5.0f)];
     [confirmBtn addTarget:self action:@selector(confirm:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:confirmBtn];
+    confirmBtn.translatesAutoresizingMaskIntoConstraints = false;
+    [[confirmBtn.rightAnchor constraintEqualToAnchor:self.view.rightAnchor constant:0] setActive:true];
+    if (@available(iOS 11.0, *)) {
+        [[confirmBtn.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:0] setActive:true];
+    } else {
+        [[confirmBtn.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor constant:0] setActive:true];
+    }
+    [[confirmBtn.widthAnchor constraintEqualToConstant:100] setActive:true];
+    [[confirmBtn.heightAnchor constraintEqualToConstant:50] setActive:true];
 }
 
 - (void)cancel:(id)sender {

--- a/VPImageCropperDemo/VPImageCropperDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/VPImageCropperDemo/VPImageCropperDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/VPImageCropperDemo/VPImageCropperDemo/Base.lproj/Main.storyboard
+++ b/VPImageCropperDemo/VPImageCropperDemo/Base.lproj/Main.storyboard
@@ -1,26 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4451" systemVersion="13A461" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3676"/>
+        <deployment version="1808" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--class Prefix:identifier View Controller-->
+        <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
                 <viewController id="vXZ-lx-hvc" customClass="VPViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="h1y-xJ-3UZ"/>
+                        <viewControllerLayoutGuide type="bottom" id="Z44-qV-SIy"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="139" y="134"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
1、Fix the problem of demo build failed on `Xcode 11`.
2、Fix the iOS 13 system, after **presentViewController**, the bottom of the **Cancel** and **confirmBtn** buttons do not display the issues.
I use **NSLayoutConstraint** , I think this is compatible with some phones before `iPhone X.`

```
   cancelBtn.translatesAutoresizingMaskIntoConstraints = false;
    [[cancelBtn.leftAnchor constraintEqualToAnchor:self.view.leftAnchor constant:0] setActive:true];
    if (@available(iOS 11.0, *)) {
        [[cancelBtn.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:0] setActive:true];
    } else {
        [[cancelBtn.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor constant:0] setActive:true];
    }
    [[cancelBtn.widthAnchor constraintEqualToConstant:100] setActive:true];
    [[cancelBtn.heightAnchor constraintEqualToConstant:50] setActive:true];
```